### PR TITLE
Fix: add missing Local Storage macOS entitlement

### DIFF
--- a/packaging/macos/Mixxx.entitlements
+++ b/packaging/macos/Mixxx.entitlements
@@ -33,6 +33,9 @@
     <!-- Persists access permission for files selected with an Open/Save dialog across restarts -->
     <key>com.apple.security.files.bookmarks.app-scope</key>
     <true/>
+    <!-- Allow access to the Local Network -->
+    <key>com.apple.security.device.local-network</key>
+    <true/>
 
     <!-- HARDENED RUNTIME ENTITLEMENTS
 

--- a/packaging/macos/Mixxx.entitlements
+++ b/packaging/macos/Mixxx.entitlements
@@ -36,6 +36,9 @@
     <!-- Allow access to the Local Network -->
     <key>com.apple.security.device.local-network</key>
     <true/>
+    <!-- Allow opening incoming network connections -->
+    <key>com.apple.security.network.server</key>
+    <true/>
 
     <!-- HARDENED RUNTIME ENTITLEMENTS
 


### PR DESCRIPTION
# Goal
This PR aims at adding the missing Local Storage macOS entitlement in order to fix the crash when OSC is enabled on the GitHub CI's built version of Mixxx using OSC liblo.