### PR TITLE
fix SQLite3 library linking error in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3218,18 +3218,28 @@ if(LOCALECOMPARE)
     get_target_property(
       _sqlite3_location
       unofficial::sqlite3::sqlite3
-      IMPORTED_LOCATION_RELEASE
+      IMPORTED_IMPLIB_RELEASE
     )
     if(NOT _sqlite3_location)
       get_target_property(
         _sqlite3_location
         unofficial::sqlite3::sqlite3
-        IMPORTED_LOCATION
+        IMPORTED_IMPLIB
       )
     endif()
     if(_sqlite3_location)
       message(STATUS "Forcing link to SQLite3 library: ${_sqlite3_location}")
       target_link_libraries(mixxx-lib PRIVATE "${_sqlite3_location}")
+    else()
+      # Fallback: try to find sqlite3.lib manually
+      message(
+        WARNING
+        "Could not find SQLite3 import library, looking for sqlite3.lib"
+      )
+      find_library(SQLITE3_LIB sqlite3)
+      if(SQLITE3_LIB)
+        target_link_libraries(mixxx-lib PRIVATE ${SQLITE3_LIB})
+      endif()
     endif()
   else()
     target_link_libraries(mixxx-lib PRIVATE SQLite::SQLite3)


### PR DESCRIPTION
Updated CMakeLists.txt to use IMPORTED_IMPLIB for SQLite3 library linking and added fallback to find sqlite3.lib if not found.

When building I got error 
Severity	Code	Description	Project	File	Line	Suppression State	Details Error	LNK1107	invalid or corrupt file: cannot read at 0x308	D:\mixxx-git\mixxx\build\x64__portable\mixxx	D:\mixxx-git\mixxx\buildenv\mixxx-deps-2.6-x64-windows-6a4e01e\installed\x64-windows\bin\sqlite3.dll	1		

The CMakeLists was linking to the dll istead of the lib

This fixes #16359